### PR TITLE
Replace the outdated `failure` crate with `err-derive`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ tags
 /target
 #**/*.rs.bk
 #Cargo.lock
+
+cargo-timing*

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ tags
 #Cargo.lock
 
 cargo-timing*
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 
 [dependencies]
 bytes = "0.4.12"
-err-derive = { version = "0.2.1", default-features = false }
 http = "0.1.19"
 httparse = "1.3.4"
 twoway = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 bytes = "0.4.12"
-failure = "0.1.6"
+err-derive = { version = "0.2.1", default-features = false }
 http = "0.1.19"
 httparse = "1.3.4"
 twoway = "0.2.1"

--- a/src/body.rs
+++ b/src/body.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use bytes::BytesMut;
 use http::header::{HeaderName, HeaderValue};
 use http::HeaderMap;
@@ -6,7 +8,6 @@ use httparse::{parse_chunk_size, parse_headers, Status, EMPTY_HEADER};
 use crate::event::Event;
 
 pub use self::writer::BodyWriter;
-use std::fmt;
 
 pub mod writer {
     use std::io::{Cursor, Write};

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,1 @@
+pub use crate::conn::ConnectionError as Error;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,1 +1,1 @@
-pub use crate::conn::ConnectionError as Error;
+pub use crate::conn::Error;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,1 +1,0 @@
-pub use crate::conn::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 
 mod body;
 mod conn;
+mod error;
 mod event;
 mod req;
 mod resp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@
 
 mod body;
 mod conn;
-mod error;
 mod event;
 mod req;
 mod resp;
@@ -19,3 +18,9 @@ pub use conn::{Client, HttpConn, Server};
 pub use event::Event;
 pub use req::ReqHead;
 pub use resp::RespHead;
+
+pub mod error {
+    pub use crate::conn::Error;
+
+    pub type Result<T> = std::result::Result<T, Error>;
+}

--- a/src/req.rs
+++ b/src/req.rs
@@ -301,13 +301,13 @@ pub type ReqHeadResult<T> = std::result::Result<T, ReqHeadError>;
 impl fmt::Display for ReqHeadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ReqHeadError::Parse(e) => {
+            Self::Parse(e) => {
                 write!(f, "An error occurred in parsing HTTP: {}", e)
             }
-            ReqHeadError::InvalidMethod(e) => {
+            Self::InvalidMethod(e) => {
                 write!(f, "Invalid method provided: {}", e)
             }
-            ReqHeadError::InvalidUriBytes(e) => {
+            Self::InvalidUriBytes(e) => {
                 write!(f, "Invalid URI bytes were provided: {}", e)
             }
         }
@@ -317,9 +317,9 @@ impl fmt::Display for ReqHeadError {
 impl std::error::Error for ReqHeadError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            ReqHeadError::Parse(e) => Some(e),
-            ReqHeadError::InvalidMethod(e) => Some(e),
-            ReqHeadError::InvalidUriBytes(e) => Some(e),
+            Self::Parse(e) => Some(e),
+            Self::InvalidMethod(e) => Some(e),
+            Self::InvalidUriBytes(e) => Some(e),
         }
     }
 }

--- a/src/req.rs
+++ b/src/req.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use bytes::{Bytes, BytesMut};
 use http::header::{HeaderName, HeaderValue};
 use http::{HeaderMap, Method, Uri, Version};
@@ -6,7 +8,6 @@ use twoway::find_bytes;
 
 use crate::body::FramingMethod;
 use crate::util::{can_keep_alive, is_chunked, maybe_content_length};
-use std::fmt;
 
 #[derive(Debug, PartialEq)]
 pub struct ReqHead {

--- a/src/resp.rs
+++ b/src/resp.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use bytes::{Bytes, BytesMut};
 use http::header::{HeaderName, HeaderValue};
 use http::{HeaderMap, Method, StatusCode, Version};
@@ -6,7 +8,6 @@ use twoway::find_bytes;
 
 use crate::body::FramingMethod;
 use crate::util::{can_keep_alive, is_chunked, maybe_content_length};
-use std::fmt;
 
 #[derive(Debug, PartialEq)]
 pub struct RespHead {

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,20 @@
-use failure::{format_err, Error};
+use err_derive::Error;
+
+#[derive(Debug, Error)]
+pub enum StateError {
+    #[error(display = "invalid state transition from the client")]
+    ClientInvalidStateTransition,
+    #[error(display = "invalid state transition from the server")]
+    ServerInvalidStateTransition,
+    #[error(display = "cannot connect without proposal")]
+    SwitchProposalMissing,
+    #[error(display = "cannot upgrade without proposal")]
+    UpgradeProposalMissing,
+    #[error(display = "not in reusable state")]
+    NotInReusableState,
+}
+
+pub type StateResult<T> = std::result::Result<T, StateError>;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum StateEvent {
@@ -29,7 +45,7 @@ pub enum Client {
 }
 
 impl Client {
-    fn send(self, event: StateEvent) -> Result<Self, Error> {
+    fn send(self, event: StateEvent) -> StateResult<Self> {
         use self::Client::*;
         use self::StateEvent::*;
 
@@ -40,7 +56,7 @@ impl Client {
             | (Done, ConnectionClosed)
             | (MustClose, ConnectionClosed)
             | (Closed, ConnectionClosed) => Closed,
-            _ => return Err(format_err!("invalid state transition")),
+            _ => return Err(StateError::ClientInvalidStateTransition),
         })
     }
 }
@@ -62,7 +78,7 @@ impl Server {
         self,
         event: StateEvent,
         switch: Option<SwitchEvent>,
-    ) -> Result<Self, Error> {
+    ) -> StateResult<Self> {
         use self::Server::*;
         use self::StateEvent::*;
         use self::SwitchEvent::*;
@@ -81,7 +97,7 @@ impl Server {
             | (Done, ConnectionClosed, None)
             | (MustClose, ConnectionClosed, None)
             | (Closed, ConnectionClosed, None) => Closed,
-            _ => return Err(format_err!("invalid state transition")),
+            _ => return Err(StateError::ServerInvalidStateTransition),
         })
     }
 }
@@ -110,7 +126,7 @@ impl State {
         (self.client, self.server)
     }
 
-    pub fn client_event(self, event: StateEvent) -> Result<Self, Error> {
+    pub fn client_event(self, event: StateEvent) -> StateResult<Self> {
         Ok(Self {
             client: self.client.send(event)?,
             server: if event == StateEvent::Request {
@@ -127,13 +143,13 @@ impl State {
         self,
         event: StateEvent,
         switch: Option<SwitchEvent>,
-    ) -> Result<Self, Error> {
+    ) -> StateResult<Self> {
         match switch {
             Some(SwitchEvent::Connect) if !self.pending_connect => {
-                return Err(format_err!("cannot connect without proposal"));
+                return Err(StateError::SwitchProposalMissing);
             }
             Some(SwitchEvent::Upgrade) if !self.pending_upgrade => {
-                return Err(format_err!("cannot upgrade without proposal"));
+                return Err(StateError::UpgradeProposalMissing);
             }
             _ => {}
         }
@@ -198,9 +214,9 @@ impl State {
         .state_transitions()
     }
 
-    pub fn start_next_cycle(self) -> Result<Self, Error> {
+    pub fn start_next_cycle(self) -> StateResult<Self> {
         if (self.client, self.server) != (Client::Done, Server::Done) {
-            return Err(format_err!("not in reusable state"));
+            return Err(StateError::NotInReusableState);
         }
         Ok(Self {
             client: Client::Idle,

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,20 +1,4 @@
-use err_derive::Error;
-
-#[derive(Debug, Error)]
-pub enum StateError {
-    #[error(display = "invalid state transition from the client")]
-    ClientInvalidStateTransition,
-    #[error(display = "invalid state transition from the server")]
-    ServerInvalidStateTransition,
-    #[error(display = "cannot connect without proposal")]
-    SwitchProposalMissing,
-    #[error(display = "cannot upgrade without proposal")]
-    UpgradeProposalMissing,
-    #[error(display = "not in reusable state")]
-    NotInReusableState,
-}
-
-pub type StateResult<T> = std::result::Result<T, StateError>;
+use std::fmt;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum StateEvent {
@@ -281,6 +265,39 @@ impl Default for State {
         Self::new()
     }
 }
+
+#[derive(Debug)]
+pub enum StateError {
+    ClientInvalidStateTransition,
+    ServerInvalidStateTransition,
+    SwitchProposalMissing,
+    UpgradeProposalMissing,
+    NotInReusableState,
+}
+
+impl fmt::Display for StateError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::ClientInvalidStateTransition => {
+                write!(f, "invalid state transition from the client")
+            }
+            Self::ServerInvalidStateTransition => {
+                write!(f, "invalid state transition from the server")
+            }
+            Self::SwitchProposalMissing => {
+                write!(f, "cannot connect without proposal")
+            }
+            Self::UpgradeProposalMissing => {
+                write!(f, "cannot upgrade without proposal")
+            }
+            Self::NotInReusableState => write!(f, "not in reusable state"),
+        }
+    }
+}
+
+impl std::error::Error for StateError {}
+
+pub type StateResult<T> = std::result::Result<T, StateError>;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
 `err-derive` is a bit more lightweight and integrates better with libraries using `std::error::Error` instead of using the shim trait `Fail`. This commit also uses enums for error variants instead of error_strings from `failure`. The previous messages are preserved as the display impls for the different variants, and hierarchy is preserved via `Error::source`.

 Using derived `Error` implementations does carry a large compilation burden, as it depends on the infamous `syn` crate. `syn` is responsible for the vast majority of compilation time, so dumping this dependency should be considered (see attached for `-Ztimings` data from debug build).

![Screenshot_2019-10-20 Cargo Build Timings — h11 0 1 0](https://user-images.githubusercontent.com/33138989/67158636-0ab89600-f33b-11e9-9b3c-af5667666fd0.png)
